### PR TITLE
working on trusted publishing

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -16,14 +16,21 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools build twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build
-        twine upload dist/*
+        pip install setuptools build
+    # pip install setuptools build twine
+    # - name: Build and publish
+    #   env:
+    #     TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+    #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      # run: |
+      #   python -m build
+      #   twine upload dist/*
+    - name: Build package
+      run: python -m build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
   build:
     name: Deploy docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
Focuses on refining the publishing process for our Python packages, specifically towards improving the security and reliability of our package distribution. The changes made in the '.github/workflows/pythonpublish.yml' file involve streamlining the build and publish steps.

The modifications include updating the installation of dependencies, removing the explicit installation of twine, and introducing a more secure method for publishing to PyPI using the 'pypa/gh-action-pypi-publish' action with a PyPI API token.

By enhancing the workflow in this manner, we are working towards a more trusted and efficient publishing mechanism for our Python packages, ensuring that the deployment process is both secure and reliable.